### PR TITLE
Android security 11.0.0 release 62

### DIFF
--- a/src/com/android/bluetooth/opp/BluetoothOppUtility.java
+++ b/src/com/android/bluetooth/opp/BluetoothOppUtility.java
@@ -47,6 +47,7 @@ import android.net.Uri;
 import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import android.os.SystemProperties;
+import android.util.EventLog;
 import android.util.Log;
 
 import com.android.bluetooth.R;
@@ -74,7 +75,11 @@ public class BluetoothOppUtility {
             new ConcurrentHashMap<Uri, BluetoothOppSendFileInfo>();
 
     public static boolean isBluetoothShareUri(Uri uri) {
-        return uri.toString().startsWith(BluetoothShare.CONTENT_URI.toString());
+        if (uri.toString().startsWith(BluetoothShare.CONTENT_URI.toString())
+                && !uri.getAuthority().equals(BluetoothShare.CONTENT_URI.getAuthority())) {
+            EventLog.writeEvent(0x534e4554, "225880741", -1, "");
+        }
+        return uri.getAuthority().equals(BluetoothShare.CONTENT_URI.getAuthority());
     }
 
     public static BluetoothOppTransferInfo queryRecord(Context context, Uri uri) {


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r62' of https://android.googlesource.com/platform/packages/apps/Bluetooth into arrow-11.0

Android security 11.0.0 release 62
Tag: https://android.googlesource.com/platform/packages/apps/Bluetooth/+/refs/tags/android-security-11.0.0_r62

Merge cherrypicks of [20078165] into security-aosp-rvc-release.

Change-Id: [I5ab63a17ea64ce8b561b92b06bf009d5ada337ad](https://android-review.googlesource.com/#/q/I5ab63a17ea64ce8b561b92b06bf009d5ada337ad)